### PR TITLE
feat: 깃허브 로그인 구현

### DIFF
--- a/src/main/java/com/example/bugonbe/auth/client/GithubApiClient.java
+++ b/src/main/java/com/example/bugonbe/auth/client/GithubApiClient.java
@@ -1,0 +1,101 @@
+package com.example.bugonbe.auth.client;
+
+import com.example.bugonbe.member.domain.ProviderType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class GithubApiClient {
+
+	private final RestTemplate restTemplate = new RestTemplate();
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Value("${oauth.github.client-id}")
+	private String clientId;
+
+	@Value("${oauth.github.client-secret}")
+	private String clientSecret;
+
+	@Value("${oauth.github.redirect-uri}")
+	private String redirectUri;
+
+	private static final String TOKEN_URI = "https://github.com/login/oauth/access_token";
+	private static final String USERINFO_URI = "https://api.github.com/user";
+	private static final String USER_EMAIL_URI = "https://api.github.com/user/emails";
+
+	public OAuthUserInfo getUserInfo(String code) {
+		String accessToken = requestAccessToken(code);
+		return requestUserInfo(accessToken);
+	}
+
+	private String requestAccessToken(String code) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		headers.setAccept(MediaType.parseMediaTypes("application/json"));
+
+		String body = UriComponentsBuilder.newInstance()
+			.queryParam("client_id", clientId)
+			.queryParam("client_secret", clientSecret)
+			.queryParam("code", code)
+			.queryParam("redirect_uri", redirectUri)
+			.build().toUri().getRawQuery();
+
+		HttpEntity<String> request = new HttpEntity<>(body, headers);
+		String response = restTemplate.postForObject(TOKEN_URI, request, String.class);
+
+		try {
+			JsonNode node = objectMapper.readTree(response);
+			return node.get("access_token").asText();
+		} catch (Exception e) {
+			throw new RuntimeException("깃허브 엑세스 토큰 요청 실패", e);
+		}
+	}
+
+	private OAuthUserInfo requestUserInfo(String accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(accessToken);
+		headers.setAccept(MediaType.parseMediaTypes("application/json"));
+
+		HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+		ResponseEntity<String> userInfoResponse = restTemplate.exchange(
+			USERINFO_URI,
+			org.springframework.http.HttpMethod.GET,
+			entity,
+			String.class
+		);
+
+		ResponseEntity<String> emailResponse = restTemplate.exchange(
+			USER_EMAIL_URI,
+			org.springframework.http.HttpMethod.GET,
+			entity,
+			String.class
+		);
+
+		try {
+			JsonNode userNode = objectMapper.readTree(userInfoResponse.getBody());
+			JsonNode emailNode = objectMapper.readTree(emailResponse.getBody());
+			String email = emailNode.get(0).get("email").asText();
+
+			return new OAuthUserInfo(
+				email,
+				userNode.get("login").asText(),
+				userNode.get("avatar_url").asText(),
+				userNode.get("id").asText(),
+				ProviderType.GITHUB
+			);
+		} catch (Exception e) {
+			throw new RuntimeException("깃허브 유저 정보 요청 실패", e);
+		}
+	}
+}

--- a/src/main/java/com/example/bugonbe/auth/processor/GithubOAuthProcessor.java
+++ b/src/main/java/com/example/bugonbe/auth/processor/GithubOAuthProcessor.java
@@ -1,0 +1,38 @@
+package com.example.bugonbe.auth.processor;
+
+import com.example.bugonbe.auth.client.GithubApiClient;
+import com.example.bugonbe.auth.client.OAuthUserInfo;
+import com.example.bugonbe.auth.domain.AccessToken;
+import com.example.bugonbe.auth.domain.RefreshToken;
+import com.example.bugonbe.auth.dto.TokenResponse;
+import com.example.bugonbe.auth.service.JwtTokenProvider;
+import com.example.bugonbe.member.domain.Member;
+import com.example.bugonbe.member.repository.MemberRepository;
+import com.example.bugonbe.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("github")
+@RequiredArgsConstructor
+public class GithubOAuthProcessor implements OAuthLoginProcessor {
+
+	private final GithubApiClient githubApiClient;
+	private final MemberService memberService;
+	private final MemberRepository memberRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public TokenResponse login(String code) {
+		OAuthUserInfo userInfo = githubApiClient.getUserInfo(code);
+
+		Member member = memberService.registerOrLogin(userInfo);
+
+		AccessToken accessToken = jwtTokenProvider.createAccessToken(member.getId());
+		RefreshToken refreshToken = jwtTokenProvider.createRefreshToken();
+
+		member.updateRefreshToken(refreshToken);
+		memberRepository.save(member);
+
+		return new TokenResponse(accessToken.getValue(), refreshToken.getValue());
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,4 +45,7 @@ oauth:
     client-id: client-id
     redirect-uri: http://localhost:8080/api/v1/oauth/kakao/callback
 
-
+  github:
+    client-id: Ov23liZzATwic5ScP2Gy
+    client-secret: b66af9b360eabde18a918b006892aed9cf2d830e
+    redirect-uri: http://localhost:8080/api/v1/oauth/github/callback


### PR DESCRIPTION
### 구현 내용
- GitHub OAuth 로그인 구현
- 이메일 중복 정책 처리